### PR TITLE
add source for gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 gem "webrick"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     activesupport (6.0.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)


### PR DESCRIPTION
Was getting an error trying to run locally when initially setting up,
```
[DEPRECATED] This Gemfile does not include an explicit global source. Not using an explicit global source may result in a different lockfile being generated depending on the gems you have installed locally before bundler is run. Instead, define a global source in your Gemfile like this: source "https://rubygems.org".
Your bundle is locked to github-pages (227) from locally installed gems, but that version can no longer be found in that source. That means the author of github-pages (227) has removed it.
You'll need to update your bundle to a version other than github-pages (227) that hasn't been removed in order to install.
```

This resolved it.