### PR TITLE
always have an events link

### DIFF
--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -6,6 +6,7 @@
 
 
 <a href="/index">Who we are</a><br>
+<a href="/meetups/past">All events</a><br>
 <a href="/photos">Event photos</a><br>
 <a target=_blank"
    rel="noopener noreferrer"
@@ -108,7 +109,5 @@
      <img src="/assets/img/monochrome.png" width="33%" style="padding-left: 33.5%"/>
   </a></span><br>
 </div>
-
-<div name="mobile-meetups-link"><a href="/meetups/past">All events</a></div><br>
 
 </div>


### PR DESCRIPTION
## Issue
I tried to show a friend the events list on their living room monitor but the link did not render. This was because the window was not wide enough.

## Solution
Always show a link to the full list of meetups. Given the meetups are the primary purpose it doesn't make a lot of sense to conditionally hide them. Displaying an event link based on pixel widths is always going to leave some diplays with an "incorrect" width.

This does repeat some info that appears later in the sidebar. I don't particularly see an issue with that but I'm open to suggestions. I just think there should always be an events link.